### PR TITLE
Update glm.sql

### DIFF
--- a/docker/db/initdb.d/glm.sql
+++ b/docker/db/initdb.d/glm.sql
@@ -32,7 +32,7 @@ $$;
 
 create or replace function area_m2 (f in glm.flash, out m2 float)
 LANGUAGE SQL IMMUTABLE AS $$
-select (f.energy::float * 152601.9) as m2;
+select (f.area::float * 152601.9) as m2;
 $$;
 
 create or replace function centroid (f in glm.flash, out centroid geometry(Point,4326))


### PR DESCRIPTION
The flash area variable was not well calculated 
You use the energy variable instead of the area variable to transform to physical values:

create or replace function area_m2 (f in glm.flash, out m2 float). LANGUAGE SQL IMMUTABLE AS $$
select (f.energy::float * 152601.9) as m2;
$$;

So, it should be f.area instead of selecting f.energy.